### PR TITLE
Define long() in Python 3

### DIFF
--- a/ffn/inference/resegmentation_analysis.py
+++ b/ffn/inference/resegmentation_analysis.py
@@ -27,6 +27,11 @@ from google3.research.neuromancer.segmentation.ffn import resegmentation_pb2
 from google3.research.neuromancer.segmentation.ffn import storage
 from google3.research.neuromancer.segmentation.python import pywrapsegment_util
 
+try:
+  long        # Python 2
+except NameError:
+  long = int  # Python 3
+
 
 class InvalidBaseSegmentatonError(Exception):
   pass

--- a/ffn/inference/storage.py
+++ b/ffn/inference/storage.py
@@ -34,6 +34,11 @@ from . import align
 from . import segmentation
 from ..utils import bounding_box
 
+try:
+  long        # Python 2
+except NameError:
+  long = int  # Python 3
+
 OriginInfo = namedtuple('OriginInfo', ['start_zyx', 'iters', 'walltime_sec'])
 
 

--- a/ffn/utils/geom_utils.py
+++ b/ffn/utils/geom_utils.py
@@ -17,6 +17,11 @@
 import numpy
 from . import vector_pb2
 
+try:
+  long        # Python 2
+except NameError:
+  long = int  # Python 3
+
 
 def ToVector3j(*args):
   """Converts from *args to Vector3j.


### PR DESCRIPTION
__long()__ was removed in Python 3 in favor of __int()__.

flake8 testing of https://github.com/google/ffn on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./compute_partitions.py:91:29: F821 undefined name 'self'
  mask = storage.build_mask(self.mask_config.masks, box.start[::-1],
                            ^
./ffn/inference/resegmentation.py:196:22: F821 undefined name 'bounding_box'
      analysis_box = bounding_box.BoundingBox(
                     ^
./ffn/inference/resegmentation.py:202:22: F821 undefined name 'bounding_box'
      analysis_box = bounding_box.BoundingBox(
                     ^
./ffn/inference/resegmentation_analysis.py:81:29: F821 undefined name 'long'
    result.deleted_voxels = long(np.sum(dels[mask]))
                            ^
./ffn/inference/resegmentation_analysis.py:83:23: F821 undefined name 'long'
  result.num_voxels = long(np.sum(reseg))
                      ^
./ffn/inference/resegmentation_analysis.py:93:7: F821 undefined name 'long'
      long(t) for t in
      ^
./ffn/inference/seed.py:159:32: F821 undefined name 'cmp'
      descending=lambda x, y: -cmp(x, y),
                               ^
./ffn/inference/storage.py:172:18: F821 undefined name 'long'
  coord = tuple([long(x) for x in match.groups()])
                 ^
./ffn/utils/geom_utils.py:43:12: F821 undefined name 'long'
    seq = [long(s) for s in seq]
           ^
9     F821 undefined name 'self'
9
```