### PR TITLE
Define cmp() in Python 3

### DIFF
--- a/ffn/inference/seed.py
+++ b/ffn/inference/seed.py
@@ -32,6 +32,12 @@ import skimage.feature
 
 from . import storage
 
+try:
+    cmp             # Python 2
+except NameError:
+    def cmp(x, y):  # Python 3
+        return (x > y) - (x < y)
+
 
 class BaseSeedPolicy(object):
   """Base class for seed policies."""


### PR DESCRIPTION
The Python 2 builtin __cmp()__ was removed in Python 3.

[flake8](http://flake8.pycqa.org) testing of https://github.com/google/ffn on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./ffn/inference/seed.py:159:32: F821 undefined name 'cmp'
      descending=lambda x, y: -cmp(x, y),
                               ^
1     F821 undefined name 'cmp'
1
```
See: https://portingguide.readthedocs.io/en/latest/comparisons.html