### PR TITLE
storage.py: Convert gfile.Open to use binary mode (py3)

### DIFF
--- a/ffn/inference/storage.py
+++ b/ffn/inference/storage.py
@@ -241,7 +241,7 @@ def threshold_segmentation(segmentation_dir, corner, labels, threshold):
     if not gfile.Exists(prob_path):
       raise ValueError('Cannot find probability map %s' % prob_path)
 
-  with gfile.Open(prob_path, 'r') as f:
+  with gfile.Open(prob_path, 'rb') as f:
     data = np.load(f)
     if 'qprob' not in data:
       raise ValueError('Invalid FFN probability map.')
@@ -256,7 +256,7 @@ def load_origins(segmentation_dir, corner):
     raise ValueError('Segmentation not found: %s, %s' % (segmentation_dir,
                                                          corner))
 
-  with gfile.Open(target_path, 'r') as f:
+  with gfile.Open(target_path, 'rb') as f:
     data = np.load(f)
     return data['origins'].item()
 
@@ -410,7 +410,7 @@ def load_segmentation(segmentation_dir, corner, allow_cpoint=False,
     raise ValueError('Segmentation not found, %s, %r.' %
                      (segmentation_dir, corner))
 
-  with gfile.Open(target_path, 'r') as f:
+  with gfile.Open(target_path, 'rb') as f:
     data = np.load(f)
     if 'segmentation' in data:
       seg = data['segmentation']


### PR DESCRIPTION
Python3 needs the binary flag to open binary files so they're not read as strings.