### PR TITLE
fix: defer np.typing annotation evaluation

### DIFF
--- a/ffn/training/examples.py
+++ b/ffn/training/examples.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """Utilities for building training examples for FFN training."""
 
+from __future__ import annotations
+
 import collections
 from concurrent import futures
 import itertools


### PR DESCRIPTION
Fixes #127

## Problem

`np.typing.XXX` is only accessible on numpy < 2.0 if `numpy.typing` has been explicitly imported earlier. Without a version constraint forcing numpy >= 2, users with numpy 1.x installed can hit:

```
AttributeError: module 'numpy' has no attribute 'typing'
```

when the annotation is evaluated at import time.

## Fix

**File**: `ffn/training/examples.py`

```diff
+ from __future__ import annotations
+
  def update_seeds(self, batched_seeds: np.typing.ArrayLike):
```

(Optional follow-up: the annotation is also narrower than the documented contract — the docstring says the argument may be an "array-like object backed by accelerator memory" (i.e. a JAX array), which `np.typing.ArrayLike` does not formally cover. `np.typing.ArrayLike | jax.typing.ArrayLike` would describe the accepted inputs more accurately.)

## Verification

- Verified the failure mechanism in isolation on numpy 1.26.4: `np.typing.ArrayLike` raises `AttributeError: module 'numpy' has no attribute 'typing'` unless `numpy.typing` has been imported first. Contrast tests confirmed that importing pandas 3.x or xarray beforehand resolves it, while importing scipy does not — i.e. whether training crashes today depends on import order, which this fix eliminates.
- With `from __future__ import annotations`, the annotation is no longer evaluated when `BatchExampleIter` is defined, making the training entry points (`train.py`, JAX path) safe on every numpy version.
- The change is annotation-only — no behavioral change.